### PR TITLE
docker-handin.md now displays correct output

### DIFF
--- a/docker/docker-handin.md
+++ b/docker/docker-handin.md
@@ -30,7 +30,7 @@ Run the script with:
 bash zip.sh
 ```
 
-This will produce a file named `git-<your-email>.zip` which is what you hand in.
+This will produce a file named `docker-<your-email>.zip` which is what you hand in.
 
 **If you submit your hand-in any other way, it will not be graded!**
 


### PR DESCRIPTION
Changed docker-handin.md to display the correct name for the output .zip file made from zip.sh